### PR TITLE
Fix a minor typo of puzzle #27

### DIFF
--- a/100-pandas-puzzles-with-solutions.ipynb
+++ b/100-pandas-puzzles-with-solutions.ipynb
@@ -602,7 +602,7 @@
    },
    "outputs": [],
    "source": [
-    "df.groupby('grp')['vals'].nlargest(3).sum(level=0)"
+    "df.groupby('grps')['vals'].nlargest(3).sum(level=0)"
    ]
   },
   {
@@ -1633,7 +1633,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 Hi, thank you for creating the exercises.

I fixed a minor typo of puzzle # 27.
I have changed `grp` to `grps`.