### PR TITLE
Fixed solution b ex 29 related to issue 17

### DIFF
--- a/100-pandas-puzzles-with-solutions.ipynb
+++ b/100-pandas-puzzles-with-solutions.ipynb
@@ -655,8 +655,7 @@
    },
    "outputs": [],
    "source": [
-    "izero = np.r_[-1, (df['X'] == 0).nonzero()[0]] # indices of zeros\n",
-    "idx = np.arange(len(df))\n",
+    "y = df['X'] != 0\n",
     "df['Y'] = idx - izero[np.searchsorted(izero - 1, idx) - 1]\n",
     "\n",
     "# http://stackoverflow.com/questions/30730981/how-to-count-distance-to-the-previous-zero-in-pandas-series/\n",


### PR DESCRIPTION
Implemented the fix suggested by @Arten013 in the issue #17 

This consists in a single, small change of the solutions notebook : in the second solution of exercice 29, replace
`x = (df1['X'] != 0).cumsum()
y = x != x.shift()`
by
`y = df['X'] != 0`