### PR TITLE
[fix] Level keyword is deprecated from pandas v1.3

### DIFF
--- a/100-pandas-puzzles-with-solutions.ipynb
+++ b/100-pandas-puzzles-with-solutions.ipynb
@@ -595,7 +595,7 @@
     "df = pd.DataFrame({'grps': list('aaabbcaabcccbbc'), \n",
     "                   'vals': [12,345,3,1,45,14,4,52,54,23,235,21,57,3,87]})\n",
     "\n",
-    "df.groupby('grps')['vals'].nlargest(3).sum(level=0)"
+    "df.groupby('grps')['vals'].nlargest(3).groupby('grps').sum()"
    ]
   },
   {


### PR DESCRIPTION
Level keyword is deprecated from pandas v1.3, replaced by groupby